### PR TITLE
chore: update dependencies to compatible version of flutter 3.38.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,9 +14,9 @@ dependencies:
   # flutter_star_prnt: ^2.3.6
   enum_to_string: ^2.0.1
   image_v3: ^3.3.0
-  network_info_plus: ^4.0.2
+  network_info_plus: ^7.0.0
   ping_discover_network_forked: ^0.0.1
-  rxdart: ^0.27.7
+  rxdart: ^0.28.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updated the packages to the latest version to add compatibility with Flutter 3.38.3